### PR TITLE
Redirected com.google.android.gms to play-services-ads, fixing export…

### DIFF
--- a/android/gradle.conf
+++ b/android/gradle.conf
@@ -6,8 +6,8 @@
 
 [dependencies]
 implementation 'com.facebook.android:facebook-android-sdk:5.+'
+implementation 'com.google.android.gms:play-services-ads'
 
 [android_defaultconfig]
 
 [global]
-


### PR DESCRIPTION
Newer versions of the android sdk no longer supports `com.google.android.gms`, causing 'does not exist' errors and an inability to export.
Redirecting to the new `play-services-ads` api fixes this.